### PR TITLE
Add 2 new args to include web vital metrics and audits 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "homepage": "https://github.com/samdutton/eperf#readme",
   "dependencies": {
-    "chrome-launcher": "^0.11.2",
+    "chrome-launcher": "^0.13.1",
     "eslint": "^6.6.0",
-    "lighthouse": "^5.6.0",
+    "lighthouse": "^6.0.0-beta.0",
     "yargs": "^14.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -181,22 +181,23 @@ function getUrl(page) {
 // The pages parameter is an array of CSV strings, each ending with a URL.
 // For example: John Lewis,homepage,https://johnlewis.com
 function audit(pages) {
-  console.log(`Run ${runIndex + 1} of ${numRuns}: ` +
+  console.log(`\nRun ${runIndex + 1} of ${numRuns}: ` +
     `URL ${pageIndex + 1} of ${pages.length}`);
   // page corresponds to a line of data in the CSV file inputFile.
   const page = pages[pageIndex];
   // The page URL is the last item on each line of CSV data.
   const url = getUrl(page);
-  // data is an array of objects: metadata and scores for each URL.
-  if (!data[pageIndex]) {
-    data[pageIndex] = {
-      metadata: page,
-    };
-  }
   launchChromeAndRunLighthouse(url, OPTIONS).then((results) => {
     if (results.runtimeError) {
-      logError(`Runtime error for ${url}:\n${results.runtimeError.message}\n`);
+      logError(`Lighthouse runtime error for ` +
+        `${url}.\n\n${results.runtimeError.message}\n`);
     } else {
+      // data is an array of objects: metadata and scores for each URL.
+      if (!data[pageIndex]) {
+        data[pageIndex] = {
+          metadata: page,
+        };
+      }
       // *** Add code here if you want to save complete Lighthouse reports ***
       const categories = Object.values(results.categories);
       for (const category of categories) {
@@ -208,8 +209,8 @@ function audit(pages) {
         }
         const score = Math.round(category.score * 100);
         if (score === 0) {
-          logError(`Zero ${category.title} score for ${url}.
-          This data will be discarded.`);
+          logError(`Zero ${category.title} score for ${url}. ` +
+            `This data will be discarded.`);
         } else {
           console.log(`${url}: ${category.title} ${score}`);
           data[pageIndex].scores[category.title].push(score);
@@ -255,12 +256,12 @@ function audit(pages) {
   }).catch((error) => {
     logError(`Caught error for ${url}:\n${error}`);
   }).finally(() => {
-    // If there are more pages to audit on this run, begin the next audit.
+    // If there are more pages to audit on this run, begin the next page audit.
     if (++pageIndex < pages.length) {
       audit(pages);
     // Otherwise, if there are more runs to do, begin the next run.
     } else if (++runIndex < numRuns) {
-      console.log('Start run', runIndex + 1);
+      console.log(`\nStart run ${runIndex + 1}`);
       pageIndex = 0;
       audit(pages);
     // Otherwise, write data to the   t file.
@@ -268,8 +269,8 @@ function audit(pages) {
       // categories is a list of Lighthouse audits completed.
       // For example: Performance, PWA, Best practices, Accessibility, SEO
       fs.appendFileSync(outputFile, getOutput(data));
-      console.log(`\nCompleted ${numRuns} run(s) for ${data.length} URL(s): ` +
-        `${numErrors} error(s)\nView output: ${outputFile}\n`);
+      console.log(`\nCompleted ${numRuns} run(s) for ${data.length} URL(s)` +
+        `with ${numErrors} error(s).\n\nView output: ${outputFile}\n`);
     }
   });
 }
@@ -293,17 +294,19 @@ function launchChromeAndRunLighthouse(url, opts, config = null) {
 function getOutput(testResults) {
   const output = [];
   for (const page of testResults) {
-    console.log(page);
+    // console.log(page);
     const pageData = [page.metadata];
     for (const scores of Object.values(page.scores)) {
       // Only options at present are median and average
-      pageData.push(scoreMethod === 'median' ? median(scores) : average(scores));
+      pageData.push(scoreMethod === 'median' ?
+        median(scores) : average(scores));
     }
 
     if (outputVitals) {
       for (const metricScores of Object.values(page.metrics)) {
         // Only options at present are median and average
-        pageData.push(scoreMethod === 'median' ? median(metricScores) : average(metricScores));
+        pageData.push(scoreMethod === 'median' ?
+          median(metricScores) : average(metricScores));
       }
     }
 
@@ -349,14 +352,16 @@ function median(array) {
   }
 }
 
+// Log an error to the console.
 function displayError(...args) {
   const color = '\x1b[31m'; // red
   const reset = '\x1b[0m'; // reset color
-  console.error(color, '>>> Error:', reset, ...args);
+  console.error(color, '\n>>> Error: ', reset, ...args);
 }
 
+// Log an error to the console and write it to the ERROR_LOG file.
 function logError(error) {
   numErrors++;
-  displayError(`>>> ${error}`);
+  displayError(`${error}\n`);
   fs.appendFileSync(ERROR_LOG, `${error}\n\n`);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,9 @@ let numRuns = 3;
 let outputFile = 'output.csv';
 let outputAudits = false;
 let outputVitals = false;
-let metrics = ['time-to-first-byte','first-contentful-paint','largest-contentful-paint','speed-index','max-potential-fid','first-cpu-idle','total-blocking-time','cumulative-layout-shift'];
+const metrics = ['time-to-first-byte', 'first-contentful-paint',
+  'largest-contentful-paint', 'speed-index', 'max-potential-fid',
+  'first-cpu-idle', 'total-blocking-time', 'cumulative-layout-shift'];
 const metadataAudits = [];
 let onlyCategories =
   ['performance', 'pwa', 'best-practices', 'accessibility', 'seo'];
@@ -45,8 +47,8 @@ const argv = require('yargs')
   .alias('i', 'input')
   .alias('m', 'metadata')
   .alias('o', 'output')
-  .alias('t','audits')
-  .alias('n','Include vitals metrics to audit output')
+  .alias('t', 'audits')
+  .alias('n', 'Include vitals metrics to audit output')
   .alias('r', 'runs')
   .alias('s', 'score-method')
   .describe('a', 'Append output to existing data in output file')
@@ -57,7 +59,7 @@ const argv = require('yargs')
   .describe('i', `Input file, default is ${inputFile}`)
   .describe('m', 'Headings for optional page metadata')
   .describe('o', `Output file, default is ${outputFile}`)
-  .describe('t',`Generate audit scores to output file`)
+  .describe('t', `Generate audit scores to output file`)
   .describe('r', 'Number of times Lighthouse audits are run for each URL, ' +
     `default is ${numRuns}`)
   .describe('s', `Method of score aggregation, default is ${scoreMethod}`)
@@ -168,7 +170,7 @@ if (okToStart) {
   audit(inputData);
 }
 
-// First two pageParts are website name and page name. 
+// First two pageParts are website name and page name.
 // URL may contain commas.
 function getUrl(page) {
   const pageParts = page.split(',');
@@ -214,7 +216,7 @@ function audit(pages) {
         }
       }
 
-      if(outputVitals){
+      if (outputVitals) {
         console.log('Adding metrics to page test.');
         for (const metric of metrics) {
           if (!data[pageIndex].metrics) {
@@ -234,22 +236,21 @@ function audit(pages) {
         }
       }
 
-      if(outputAudits){
-        console.log('Adding audits to output')
+      if (outputAudits) {
+        console.log('Adding audits to output');
         const audits = Object.values(results.audits);
-        for (const audit of audits){
-          //check if metadata for audits not added yet
-          if(metadataAudits.length < audits.length){
+        for (const audit of audits) {
+          // Check if metadata for audits not added yet.
+          if (metadataAudits.length < audits.length) {
             metadataAudits.push(audit.title);
           }
 
-          if(!data[pageIndex].audits){
+          if (!data[pageIndex].audits) {
             data[pageIndex].audits = {};
           }
           data[pageIndex].audits[audit.id] = audit.score;
         }
       }
-      
     }
   }).catch((error) => {
     logError(`Caught error for ${url}:\n${error}`);
@@ -299,14 +300,14 @@ function getOutput(testResults) {
       pageData.push(scoreMethod === 'median' ? median(scores) : average(scores));
     }
 
-    if(outputVitals){
+    if (outputVitals) {
       for (const metricScores of Object.values(page.metrics)) {
         // Only options at present are median and average
         pageData.push(scoreMethod === 'median' ? median(metricScores) : average(metricScores));
       }
     }
 
-    if(outputAudits){
+    if (outputAudits) {
       for (const audit of Object.values(page.audits)) {
         // Only options at present are median and average
         pageData.push(audit);
@@ -318,12 +319,13 @@ function getOutput(testResults) {
   // For example: Name,Page type,URL,Performance,PWA, Accessibility,SEO
   const categories = Object.keys(data[0].scores).join(',');
   const audits = metadataAudits.join(',');
-  if(outputAudits)
-    return `${metadataValues},${categories},${audits}\n${output.join('\n')}`; 
-  else if(outputVitals)
-    return `${metadataValues},${categories},${metrics}\n${output.join('\n')}`; 
-  else
+  if (outputAudits) {
+    return `${metadataValues},${categories},${audits}\n${output.join('\n')}`;
+  } else if (outputVitals) {
+    return `${metadataValues},${categories},${metrics}\n${output.join('\n')}`;
+  } else {
     return `${metadataValues},${categories}\n${output.join('\n')}`;
+  }
 }
 
 


### PR DESCRIPTION
Added 2 new arguments to generate the output
* `-n` to include the metrics from LH6 beta (bumped the LH version to V6 beta.
* `-t` to include the audits